### PR TITLE
add a configuration for read time out. in websockets the default valu…

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttConnectOptions.java
@@ -77,6 +77,7 @@ public class MqttConnectOptions {
 
 	// Client Operation Parameters
 	private int executorServiceTimeout = 1; // How long to wait in seconds when terminating the executor service.
+	private int soTimeout = 1000;
 
 	/**
 	 * Constructs a new <code>MqttConnectOptions</code> object using the default
@@ -644,6 +645,27 @@ public class MqttConnectOptions {
 	
 	public int getExecutorServiceTimeout() {
 		return executorServiceTimeout;
+	}
+
+	/**
+	 * *  With this option set
+	 * *  to a non-zero timeout, a read() call on the InputStream associated with
+	 * *  this Socket will block for only this amount of time.  If the timeout
+	 * *  expires, a <B>java.net.SocketTimeoutException</B> is raised, though the
+	 * *  Socket is still valid. The option <B>must</B> be enabled
+	 * *  prior to entering the blocking operation to have effect. The
+	 * *  timeout must be {@code > 0}.
+	 * *  A timeout of zero is interpreted as an infinite timeout.
+	 * *  Default value is 1000
+	 *
+	 * @param soTimeout The connection timeout
+	 */
+	public void setSoTimeout(int soTimeout) {
+		this.soTimeout = soTimeout;
+	}
+
+	public int getSoTimeout() {
+		return soTimeout;
 	}
 
 	/**

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModule.java
@@ -41,6 +41,7 @@ public class TCPNetworkModule implements NetworkModule {
 	private String host;
 	private int port;
 	private int conTimeout;
+	private int soTimeout = 1000;
 
 	/**
 	 * Constructs a new TCPNetworkModule using the specified host and
@@ -72,7 +73,7 @@ public class TCPNetworkModule implements NetworkModule {
 			SocketAddress sockaddr = new InetSocketAddress(host, port);
 			socket = factory.createSocket();
 			socket.connect(sockaddr, conTimeout*1000);
-			socket.setSoTimeout(1000);
+			socket.setSoTimeout(soTimeout);
 		}
 		catch (ConnectException ex) {
 			//@TRACE 250=Failed to create TCP socket
@@ -105,6 +106,20 @@ public class TCPNetworkModule implements NetworkModule {
 	 */
 	public void setConnectTimeout(int timeout) {
 		this.conTimeout = timeout;
+	}
+
+	/**
+	 * * With this option set * to a non-zero timeout, a read() call on the
+	 * InputStream associated with * this Socket will block for only this amount of
+	 * time. If the timeout * expires, a <B>java.net.SocketTimeoutException</B> is
+	 * raised, though the * Socket is still valid. The option <B>must</B> be enabled
+	 * * prior to entering the blocking operation to have effect. The * timeout must
+	 * be {@code > 0}. * A timeout of zero is interpreted as an infinite timeout.
+	 *
+	 * @param soTimeout The connection timeout
+	 */
+	public void setSoTimeout(int soTimeout) {
+		this.soTimeout = soTimeout;
 	}
 
 	public String getServerURI() {

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/TCPNetworkModuleFactory.java
@@ -58,6 +58,7 @@ public class TCPNetworkModuleFactory implements NetworkModuleFactory {
 		}
 		TCPNetworkModule networkModule = new TCPNetworkModule(factory, host, port, clientId);
 		networkModule.setConnectTimeout(options.getConnectionTimeout());
+		networkModule.setSoTimeout(options.getSoTimeout());
 		return networkModule;
 	}
 }

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModuleFactory.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/websocket/WebSocketNetworkModuleFactory.java
@@ -54,6 +54,7 @@ public class WebSocketNetworkModuleFactory implements NetworkModuleFactory {
 		WebSocketNetworkModule netModule = new WebSocketNetworkModule(factory, brokerUri.toString(), host, port,
 				clientId, options.getCustomWebSocketHeaders());
 		netModule.setConnectTimeout(options.getConnectionTimeout());
+		netModule.setSoTimeout(options.getSoTimeout());
 		return netModule;
 	}
 }


### PR DESCRIPTION
…e is 1000 that bring connection issue described in issue

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] This change is against the develop branch, **not** master.
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Code got from that issue: https://github.com/eclipse/paho.mqtt.java/pull/684